### PR TITLE
postgis::client - new class + fixed confusing naming

### DIFF
--- a/manifests/classes/postgis-base.pp
+++ b/manifests/classes/postgis-base.pp
@@ -8,9 +8,14 @@ shared by the different distributions
 */
 class postgis::base {
 
-  package {"postgis":
-    ensure => present,
+  include postgis::client
+
+  # this package is declined in different postgresql-<version>-postgis
+  # packages depending on the distribution.
+  # It contains stuff such as spatial_ref_sys.sql and libpostgis.so.
+  package { "postgresql-postgis":
+    ensure  => present,
     require => Postgresql::Cluster["main"],
-  }                                      
-  
+  }
+
 }

--- a/manifests/classes/postgis-client.pp
+++ b/manifests/classes/postgis-client.pp
@@ -1,0 +1,18 @@
+/*
+
+==Class: postgis::client
+
+This class installs pgsql2shp and shp2pgsql which are part of
+the postgis package.
+
+The idea is that stuff defined in this class should not depend
+on the whole postgresql server suite.
+
+*/
+class postgis::client {
+
+  package { "postgis":
+    ensure => present,
+  }
+
+}

--- a/manifests/classes/postgis-debian-base.pp
+++ b/manifests/classes/postgis-debian-base.pp
@@ -24,7 +24,8 @@ class postgis::debian::base inherits postgis::base {
     unless  => "psql -l |grep template_postgis",
     user    => postgres,
     require => [ 
-      Package["postgis"],
+      Package["postgresql-postgis"],
+      Service["postgresql"],
       File["/usr/local/bin/make-postgresql-postgis-template.sh"],
     ]
   }

--- a/manifests/classes/postgis-debian-v8-3.pp
+++ b/manifests/classes/postgis-debian-v8-3.pp
@@ -17,7 +17,7 @@ class postgis::debian::v8-3 inherits postgis::debian::base {
 
   case $lsbdistcodename {
     "etch", "lenny" : { 
-      Package["postgis"] {
+      Package["postgresql-postgis"] {
         name => "postgresql-8.3-postgis"
       }
     }

--- a/manifests/classes/postgis-debian-v8-4.pp
+++ b/manifests/classes/postgis-debian-v8-4.pp
@@ -17,7 +17,7 @@ class postgis::debian::v8-4 inherits postgis::debian::base {
 
   case $lsbdistcodename {
     "lenny", "squeeze" : {
-      Package["postgis"] {
+      Package["postgresql-postgis"] {
         name => "postgresql-8.4-postgis"
       }
     }

--- a/manifests/classes/postgis-debian-v9-0.pp
+++ b/manifests/classes/postgis-debian-v9-0.pp
@@ -10,7 +10,7 @@ class postgis::debian::v9-0 inherits postgis::debian::base {
 
   case $lsbdistcodename {
     squeeze : { 
-      Package["postgis"] {
+      Package["postgresql-postgis"] {
         name => "postgresql-9.0-postgis"
       }
     }

--- a/manifests/classes/postgis-ubuntu-base.pp
+++ b/manifests/classes/postgis-ubuntu-base.pp
@@ -24,7 +24,8 @@ class postgis::ubuntu::base inherits postgis::base {
     unless => "psql -l |grep template_postgis",
     user => postgres,
     require => [ 
-      Package["postgis"],
+      Package["postgresql-postgis"],
+      Service["postgresql"],
       File["/usr/local/bin/make-postgresql-postgis-template.sh"]
     ]
   }

--- a/manifests/classes/postgis-ubuntu-v8-4.pp
+++ b/manifests/classes/postgis-ubuntu-v8-4.pp
@@ -10,7 +10,7 @@ class postgis::ubuntu::v8-4 inherits postgis::ubuntu::base {
 
   case $lsbdistcodename {
     "lucid" : { 
-      Package["postgis"] {
+      Package["postgresql-postgis"] {
         name => "postgresql-8.4-postgis"
       }
     }


### PR DESCRIPTION
New class postgis::client which installs pgsql2shp without any dependencies on
postgresql server pieces (useful when postgresql is on a remote node).

Renamed Package[postgis] to Package[postgresql-postgis] which better represents
what it installs, and doesn't conflict with the name of the _real_ postgis
package.
