### PR TITLE
Add postgresql 9.1 support

### DIFF
--- a/manifests/debian/v9_1.pp
+++ b/manifests/debian/v9_1.pp
@@ -1,10 +1,10 @@
 #
-# ==Class: postgis::debian::v9-1
+# ==Class: postgis::debian::v9_1
 #
 # Requires:
 #  - Class['apt::preferences']
 #
-class postgis::debian::v9-1 inherits postgis::debian::base {
+class postgis::debian::v9_1 inherits postgis::debian::base {
 
   case $::lsbdistcodename {
     squeeze : {

--- a/manifests/v9_1.pp
+++ b/manifests/v9_1.pp
@@ -1,8 +1,8 @@
-class postgis::v9-1 {
+class postgis::v9_1 {
   case $::operatingsystem {
     Debian: {
       case $::lsbdistcodename {
-        squeeze : { include postgis::debian::v9-1 }
+        squeeze : { include postgis::debian::v9_1 }
         default : { fail "${name} not available for ${::operatingsystem}/${::lsbdistcodename}"}
       }
     }


### PR DESCRIPTION
Note that `make-postgresql-postgis-template.sh` was not updated because the postgis activation is now much more simple. example:

```
createdb foobar
psql -d foobar -c "CREATE EXTENSION postgis;"
```
