### PR TITLE
Fix template script

### DIFF
--- a/files/usr/local/bin/make-postgresql-postgis-template.sh
+++ b/files/usr/local/bin/make-postgresql-postgis-template.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 TMPL_NAME="template_postgis"
-psql -l |grep -q template_postgis && exit
 
-PG_VERSION=$(pg_lsclusters --no-header | awk '{ print $1 }')
+# TODO: add support for multiple/non-default clusters
+PG_VERSION=$(pg_lsclusters --no-header | grep 5432 | awk '{ print $1 }')
 
 case "$PG_VERSION" in
 '8.3')
@@ -22,7 +22,14 @@ PG_SPATIAL_REF="/usr/share/postgresql/9.0/contrib/postgis-1.5/spatial_ref_sys.sq
 PG_POSTGIS="/usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql"
 PG_SPATIAL_REF="/usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql"
 ;;
+*)
+echo "No support for $PG_VERSION in $0"
+exit 1
+;;
 esac
+
+test -e $PG_POSTGIS || exit 1
+test -e $PG_SPATIAL_REF || exit 1
 
 cat << EOF | psql -q
 CREATE DATABASE $TMPL_NAME WITH template = template1;
@@ -30,8 +37,8 @@ UPDATE pg_database SET datistemplate = TRUE WHERE datname = '$TMPL_NAME';
 EOF
 
 createlang plpgsql $TMPL_NAME
-psql -q -d $TMPL_NAME -f $PG_POSTGIS
-psql -q -d $TMPL_NAME -f $PG_SPATIAL_REF
+psql -q -d $TMPL_NAME -f $PG_POSTGIS || exit 1
+psql -q -d $TMPL_NAME -f $PG_SPATIAL_REF || exit 1
 
 cat << EOF | psql -d $TMPL_NAME
 GRANT ALL ON geometry_columns TO PUBLIC;


### PR DESCRIPTION
BIG FAT WARNING:
As this script silently failed up to now (on every postgresql 9.1 at least), we now must check if postgis is properly installed on every GIS database created on 9.1. If it has been manually installed by someone, chances is that postgis doesn't work properly (because superuser permissions are needed to create postgis functions).
