### PR TITLE
fix postgis template creation script for 2.0

### DIFF
--- a/files/usr/local/bin/make-postgresql-postgis-template.sh
+++ b/files/usr/local/bin/make-postgresql-postgis-template.sh
@@ -10,17 +10,10 @@ case "$PG_VERSION" in
 PG_POSTGIS="/usr/share/postgresql-8.3-postgis/lwpostgis.sql"
 PG_SPATIAL_REF="/usr/share/postgresql-8.3-postgis/spatial_ref_sys.sql"
 ;;
-'8.4')
-PG_POSTGIS="/usr/share/postgresql/8.4/contrib/postgis-1.5/postgis.sql"
-PG_SPATIAL_REF="/usr/share/postgresql/8.4/contrib/postgis-1.5/spatial_ref_sys.sql"
-;;
-'9.0')
-PG_POSTGIS="/usr/share/postgresql/9.0/contrib/postgis-1.5/postgis.sql"
-PG_SPATIAL_REF="/usr/share/postgresql/9.0/contrib/postgis-1.5/spatial_ref_sys.sql"
-;;
-'9.1')
-PG_POSTGIS="/usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql"
-PG_SPATIAL_REF="/usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql"
+'8.4'|'9.0'|'9.1')
+PGIS_VERSION=$(ls -d /usr/share/postgresql/$PG_VERSION/contrib/postgis* | cut -d- -f2)
+PG_POSTGIS="/usr/share/postgresql/$PG_VERSION/contrib/postgis-$PGIS_VERSION/postgis.sql"
+PG_SPATIAL_REF="/usr/share/postgresql/$PG_VERSION/contrib/postgis-$PGIS_VERSION/spatial_ref_sys.sql"
 ;;
 *)
 echo "No support for $PG_VERSION in $0"
@@ -28,8 +21,8 @@ exit 1
 ;;
 esac
 
-test -e $PG_POSTGIS || exit 1
-test -e $PG_SPATIAL_REF || exit 1
+test -e $PG_POSTGIS || (echo "File not found - $PG_POSTGIS" && exit 1)
+test -e $PG_SPATIAL_REF || (echo "File not found - $PG_POSTGIS" && exit 1)
 
 cat << EOF | psql -q
 CREATE DATABASE $TMPL_NAME WITH template = template1;


### PR DESCRIPTION
Autodetect installed version of postgis. With postgresql 9.1, we now install
postgis 2.0 instead of 1.5. This script is backwards compatible.
