### PR TITLE
Don't include postgresql::params in postgis::params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
 class postgis::params {
 
-  include postgresql::params
-
-  $default_version = $postgresql::params::default_version
+  validate_re($::postgres_default_version, '\S+')
+  $default_version = $::postgres_default_version
 
 }


### PR DESCRIPTION
The default_version is actually always overridden as version is a mandatory parameter of postgis class.
