### PR TITLE
Fix wrong links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This module is provided by [Camptocamp](http://www.camptocamp.com/)
 ## Contributing
 
 Please report bugs and feature request using [GitHub issue
-tracker](https://github.com/camptocamp/puppet-dhcp/issues).
+tracker](https://github.com/camptocamp/puppet-postgis/issues).
 
 For pull requests, it is very much appreciated to check your Puppet manifest
-with [puppet-lint](https://github.com/camptocamp/puppet-dhcp/issues) to follow
+with [puppet-lint](http://puppet-lint.com/) to follow
 the recommended Puppet style guidelines from the
 [Puppet Labs style guide](http://docs.puppetlabs.com/guides/style_guide.html).
 


### PR DESCRIPTION
I suppose that having the issue tracker link point to another repo is a typo, also the link to puppet-lint is wrong.
