### PR TITLE
Use $::postgresql::server::_version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,11 +12,11 @@ class postgis(
   }
 
   $script_path = $::osfamily ? {
-    Debian => $::postgresql::server::version ? {
+    Debian => $::postgresql::server::_version ? {
       '8.3'   => '/usr/share/postgresql-8.3-postgis',
-      default => "/usr/share/postgresql/${::postgresql::server::version}/contrib/postgis-1.5",
+      default => "/usr/share/postgresql/${::postgresql::server::_version}/contrib/postgis-1.5",
     },
-    RedHat => "/usr/pgsql-${::postgresql::server::version}/share/contrib/postgis-1.5",
+    RedHat => "/usr/pgsql-${::postgresql::server::_version}/share/contrib/postgis-1.5",
   }
 
   class { 'postgresql::server::postgis': }
@@ -43,7 +43,7 @@ class postgis(
     require => Exec['createlang plpgsql template_postgis'],
   }
 
-  if $::postgresql::server::version >= '9.1' {
+  if $::postgresql::server::_version >= '9.1' {
     postgresql::server::table_grant { 'GRANT ALL ON geometry_columns TO public':
       privilege => 'ALL',
       table     => 'geometry_columns',


### PR DESCRIPTION
$::postgresql::server::version (w/o underscore) is not set anymore when the
$version parameter is not used in the latest version of the module, so we
have to use _version to get the right value but still be backwards compatible
with postgresql::server's $version parameter.
