### PR TITLE
Issue with $script_path for members of the RedHat operating system family

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class postgis {
         '8.3'   => '/usr/share/postgresql-8.3-postgis',
         default => "/usr/share/postgresql/${::postgresql::globals::globals_version}/contrib/postgis-${::postgresql::globals::globals_postgis_version}",
       },
-      'RedHat' => "/usr/pgsql-${::postgresql::globals::globals_version}}/share/contrib/postgis-${::postgresql::globals::globals_postgis_version}",
+      'RedHat' => "/usr/pgsql-${::postgresql::globals::globals_version}/share/contrib/postgis-${::postgresql::globals::globals_postgis_version}",
     }
     Exec {
       path => ['/usr/bin', '/bin', ],


### PR DESCRIPTION
Hello Everyone,

I've found that it was necessary to remove an extra "}" character within the variable declaration for $script_path for RedHat and related operating systems (e. g. CentOS).  May I please introduce this modification into the current code base?

Thank you very much for your contribution, and I greatly look forward to future releases.